### PR TITLE
公开招募 BossHunter 项目维护者

### DIFF
--- a/COMMUNITY_PROJECTS.md
+++ b/COMMUNITY_PROJECTS.md
@@ -2,14 +2,14 @@
 
 本文件是社群收录项目的范围清单。只有列入 [`config/community.json`](./config/community.json) 的仓库才会被每月任务核对状态；未来收录或移除项目必须通过公开 PR 修改本清单与配置。
 
-| 项目 | 定位 | 默认分支 | 当前许可证口径 |
-| --- | --- | --- | --- |
-| [powerycy/BossHunter](https://github.com/powerycy/BossHunter) | AI 求职 Agent 与自动化流程 | `main` | 自定义非商业许可证；商用需事先书面授权 |
-| [powerycy/personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页与 HTML PPT 生成 Skill | `main` | 自定义非商业许可证；商用需事先书面授权 |
-| [powerycy/goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 恋爱军师与关系支持 Skill | `main` | MIT License |
-| [powerycy/qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验与技术内容写作 Skill | `main` | PolyForm Noncommercial License 1.0.0 |
-| [powerycy/multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审与裁判投票 Skill | `main` | PolyForm Noncommercial License 1.0.0 |
-| [powerycy/multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 Skill | `main` | PolyForm Noncommercial License 1.0.0 |
+| 项目 | 定位 | 维护者 | 任期 | 状态 | 默认分支 | 当前许可证口径 |
+| --- | --- | --- | --- | --- | --- | --- |
+| [powerycy/BossHunter](https://github.com/powerycy/BossHunter) | AI 求职 Agent 与自动化流程 |  |  | [招募中](./README.md#bosshunter-项目维护者招募) | `main` | 自定义非商业许可证；商用需事先书面授权 |
+| [powerycy/personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页与 HTML PPT 生成 Skill |  |  |  | `main` | 自定义非商业许可证；商用需事先书面授权 |
+| [powerycy/goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 恋爱军师与关系支持 Skill |  |  |  | `main` | MIT License |
+| [powerycy/qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验与技术内容写作 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
+| [powerycy/multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审与裁判投票 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
+| [powerycy/multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
 
 ## 商业化说明
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-23 -->
+<!-- README_SYNC: source=working-tree; updated=2026-08-24 -->
 
 <p align="center">
   简体中文 · <a href="./README_EN.md">English</a>
@@ -46,16 +46,22 @@
 
 ## 首批开放共建项目
 
-| 项目 | 你可以参与什么 |
-| --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |
+| 项目 | 你可以参与什么 | 维护者 | 任期 | 状态 |
+| --- | --- | --- | --- | --- |
+| [BossHunter](https://github.com/powerycy/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |  |  | [招募中](#bosshunter-项目维护者招募) |
+| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |  |  |  |
+| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |  |  |  |
+| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |  |  |  |
+| [multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |  |  |  |
+| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |  |  |  |
 
 完整范围和许可证以[当前共建项目清单](./COMMUNITY_PROJECTS.md)为准。选择一个你真正感兴趣的项目，先看 README、Issue 和许可证，再从一个可以验证的小问题开始。
+
+### BossHunter 项目维护者招募
+
+BossHunter 正在招募项目维护者，个人或团队均可申请。
+
+请将简历发送至 **247133278@qq.com**，并说明你本人或你的团队具备维护此项目的能力。
 
 ## 加入社群，一起共建
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-23 -->
+<!-- README_SYNC: source=working-tree; updated=2026-08-24 -->
 
 <p align="center">
   <a href="./README.md">简体中文</a> · English
@@ -46,16 +46,22 @@
 
 ## First projects open for co-building
 
-| Project | Ways to contribute |
-| --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | Job-search agents, automation, testing, and safety boundaries |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | Multi-model review, judge voting, and reliability checks |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |
+| Project | Ways to contribute | Maintainer | Term | Status |
+| --- | --- | --- | --- | --- |
+| [BossHunter](https://github.com/powerycy/BossHunter) | Job-search agents, automation, testing, and safety boundaries |  |  | [Recruiting](#bosshunter-project-maintainer-recruitment) |
+| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |  |  |  |
+| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |  |  |  |
+| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |  |  |  |
+| [multi-model-review](https://github.com/powerycy/multi-model-review) | Multi-model review, judge voting, and reliability checks |  |  |  |
+| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |  |  |  |
 
 The [community project registry](./COMMUNITY_PROJECTS.md) is the source of truth for scope and licensing. Read the project's README, issues, and license before contributing, then begin with one verifiable problem.
+
+### BossHunter project maintainer recruitment
+
+BossHunter is recruiting a project maintainer. Individuals and teams are both welcome to apply.
+
+Send your résumé to **247133278@qq.com** and explain how you or your team are equipped to maintain the project.
 
 ## Join and build with us
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-23 -->
+<!-- README_SYNC: source=working-tree; updated=2026-08-24 -->
 
 <p align="center">
   简体中文 · <a href="./README_EN.md">English</a>
@@ -46,16 +46,22 @@
 
 ## 首批开放共建项目
 
-| 项目 | 你可以参与什么 |
-| --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |
+| 项目 | 你可以参与什么 | 维护者 | 任期 | 状态 |
+| --- | --- | --- | --- | --- |
+| [BossHunter](https://github.com/powerycy/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |  |  | [招募中](#bosshunter-项目维护者招募) |
+| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |  |  |  |
+| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |  |  |  |
+| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |  |  |  |
+| [multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |  |  |  |
+| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |  |  |  |
 
 完整范围和许可证以[当前共建项目清单](../COMMUNITY_PROJECTS.md)为准。选择一个你真正感兴趣的项目，先看 README、Issue 和许可证，再从一个可以验证的小问题开始。
+
+### BossHunter 项目维护者招募
+
+BossHunter 正在招募项目维护者，个人或团队均可申请。
+
+请将简历发送至 **247133278@qq.com**，并说明你本人或你的团队具备维护此项目的能力。
 
 ## 加入社群，一起共建
 

--- a/profile/README_EN.md
+++ b/profile/README_EN.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-23 -->
+<!-- README_SYNC: source=working-tree; updated=2026-08-24 -->
 
 <p align="center">
   <a href="./README.md">简体中文</a> · English
@@ -46,16 +46,22 @@
 
 ## First projects open for co-building
 
-| Project | Ways to contribute |
-| --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | Job-search agents, automation, testing, and safety boundaries |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | Multi-model review, judge voting, and reliability checks |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |
+| Project | Ways to contribute | Maintainer | Term | Status |
+| --- | --- | --- | --- | --- |
+| [BossHunter](https://github.com/powerycy/BossHunter) | Job-search agents, automation, testing, and safety boundaries |  |  | [Recruiting](#bosshunter-project-maintainer-recruitment) |
+| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |  |  |  |
+| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |  |  |  |
+| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |  |  |  |
+| [multi-model-review](https://github.com/powerycy/multi-model-review) | Multi-model review, judge voting, and reliability checks |  |  |  |
+| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |  |  |  |
 
 The [community project registry](../COMMUNITY_PROJECTS.md) is the source of truth for scope and licensing. Read the project's README, issues, and license before contributing, then begin with one verifiable problem.
+
+### BossHunter project maintainer recruitment
+
+BossHunter is recruiting a project maintainer. Individuals and teams are both welcome to apply.
+
+Send your résumé to **247133278@qq.com** and explain how you or your team are equipped to maintain the project.
 
 ## Join and build with us
 


### PR DESCRIPTION
## 调整内容

- 为首批六个项目增加维护者、任期和状态三列
- BossHunter 状态标记为「招募中」，维护者和任期暂时留空
- 其他项目的新栏目暂时留空
- 增加 BossHunter 项目维护者申请说明
- 申请方式为发送简历至 247133278@qq.com，并说明个人或团队的项目维护能力
- 同步中文、英文和组织主页

## 校验

- 3 项单元测试通过
- 社区仓库校验通过
- 两组中英文 README 配对校验通过
- Markdown 差异检查通过