### PR TITLE
Update community projects after organization migration

### DIFF
--- a/COMMUNITY_PROJECTS.md
+++ b/COMMUNITY_PROJECTS.md
@@ -4,12 +4,12 @@
 
 | 项目 | 定位 | 维护者 | 任期 | 状态 | 默认分支 | 当前许可证口径 |
 | --- | --- | --- | --- | --- | --- | --- |
-| [powerycy/BossHunter](https://github.com/powerycy/BossHunter) | AI 求职 Agent 与自动化流程 |  |  | [招募中](./README.md#bosshunter-项目维护者招募) | `main` | 自定义非商业许可证；商用需事先书面授权 |
-| [powerycy/personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页与 HTML PPT 生成 Skill |  |  |  | `main` | 自定义非商业许可证；商用需事先书面授权 |
-| [powerycy/goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 恋爱军师与关系支持 Skill |  |  |  | `main` | MIT License |
-| [powerycy/qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验与技术内容写作 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
-| [powerycy/multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审与裁判投票 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
-| [powerycy/multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
+| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | AI 求职 Agent 与自动化流程 |  |  | [招募中](./README.md#bosshunter-项目维护者招募) | `main` | 自定义非商业许可证；商用需事先书面授权 |
+| [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 个人主页与 HTML PPT 生成 Skill |  |  |  | `main` | 自定义非商业许可证；商用需事先书面授权 |
+| [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI 恋爱军师与关系支持 Skill |  |  |  | `main` | MIT License |
+| [shengjidaguai-china/qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 事实核验与技术内容写作 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
+| [shengjidaguai-china/multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 多模型评审与裁判投票 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
+| [shengjidaguai-china/multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
 
 ## 商业化说明
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,15 +4,15 @@
 
 本页面每月核对一次已收录仓库的公开状态、默认分支、最后推送时间和 GitHub 检测到的许可证。贡献署名和贡献者页面由各项目独立维护。
 
-最近检查：`2026-08-23T08:21:30.328284Z`
+最近检查：`2026-08-26T12:42:47.607745Z`
 
 | 项目 | 状态 | 默认分支 | 最后推送 | GitHub 许可证识别 |
 | --- | --- | --- | --- | --- |
-| [powerycy/BossHunter](https://github.com/powerycy/BossHunter) | 公开 | `main` | 2026-08-23T07:11:42Z | 自定义／未识别 |
-| [powerycy/personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 公开 | `main` | 2026-08-17T07:59:03Z | 自定义／未识别 |
-| [powerycy/goutoujunshi](https://github.com/powerycy/goutoujunshi) | 公开 | `main` | 2026-08-17T07:00:07Z | MIT |
-| [powerycy/qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 公开 | `main` | 2026-08-13T10:54:58Z | 自定义／未识别 |
-| [powerycy/multi-model-review](https://github.com/powerycy/multi-model-review) | 公开 | `main` | 2026-08-13T10:54:52Z | 自定义／未识别 |
-| [powerycy/multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 公开 | `main` | 2026-08-06T07:55:25Z | 自定义／未识别 |
+| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 公开 | `main` | 2026-08-25T11:10:16Z | 自定义／未识别 |
+| [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 公开 | `main` | 2026-08-17T07:59:03Z | 自定义／未识别 |
+| [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | 公开 | `main` | 2026-08-25T10:58:00Z | MIT |
+| [shengjidaguai-china/qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 公开 | `main` | 2026-08-13T10:54:58Z | 自定义／未识别 |
+| [shengjidaguai-china/multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 公开 | `main` | 2026-08-13T10:54:52Z | 自定义／未识别 |
+| [shengjidaguai-china/multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 公开 | `main` | 2026-08-06T07:55:25Z | 自定义／未识别 |
 
 GitHub 显示“自定义／未识别”时，以仓库实际 `LICENSE` 文件为准。人工确认的范围和许可证说明见 [`COMMUNITY_PROJECTS.md`](./COMMUNITY_PROJECTS.md)。

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
   简体中文 · <a href="./README_EN.md">English</a>
 </p>
 
-<p align="center">
-  <img src="./assets/logo.png" width="180" alt="升级打怪开源社区 Logo">
-</p>
-
 <h1 align="center">升级打怪开源社区</h1>
 
 <p align="center">
@@ -48,12 +44,12 @@
 
 | 项目 | 你可以参与什么 | 维护者 | 任期 | 状态 |
 | --- | --- | --- | --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |  |  | [招募中](#bosshunter-项目维护者招募) |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |  |  |  |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |  |  |  |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |  |  |  |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |  |  |  |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |  |  |  |
+| [BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |  |  | [招募中](#bosshunter-项目维护者招募) |
+| [personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |  |  |  |
+| [goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |  |  |  |
+| [qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |  |  |  |
+| [multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |  |  |  |
+| [multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |  |  |  |
 
 完整范围和许可证以[当前共建项目清单](./COMMUNITY_PROJECTS.md)为准。选择一个你真正感兴趣的项目，先看 README、Issue 和许可证，再从一个可以验证的小问题开始。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,10 +4,6 @@
   <a href="./README.md">简体中文</a> · English
 </p>
 
-<p align="center">
-  <img src="./assets/logo.png" width="180" alt="Level Up Open Source Community logo">
-</p>
-
 <h1 align="center">Level Up Open Source Community</h1>
 
 <p align="center">
@@ -48,12 +44,12 @@
 
 | Project | Ways to contribute | Maintainer | Term | Status |
 | --- | --- | --- | --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | Job-search agents, automation, testing, and safety boundaries |  |  | [Recruiting](#bosshunter-project-maintainer-recruitment) |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |  |  |  |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |  |  |  |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |  |  |  |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | Multi-model review, judge voting, and reliability checks |  |  |  |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |  |  |  |
+| [BossHunter](https://github.com/shengjidaguai-china/BossHunter) | Job-search agents, automation, testing, and safety boundaries |  |  | [Recruiting](#bosshunter-project-maintainer-recruitment) |
+| [personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |  |  |  |
+| [goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |  |  |  |
+| [qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |  |  |  |
+| [multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | Multi-model review, judge voting, and reliability checks |  |  |  |
+| [multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |  |  |  |
 
 The [community project registry](./COMMUNITY_PROJECTS.md) is the source of truth for scope and licensing. Read the project's README, issues, and license before contributing, then begin with one verifiable problem.
 

--- a/config/community.json
+++ b/config/community.json
@@ -1,31 +1,31 @@
 {
   "community_name": "升级打怪开源社区",
-  "owner": "powerycy",
+  "owner": "shengjidaguai-china",
   "timezone": "Asia/Shanghai",
   "monthly_schedule": "10 9 1 * *",
   "projects": [
     {
-      "repository": "powerycy/BossHunter",
+      "repository": "shengjidaguai-china/BossHunter",
       "default_branch": "main"
     },
     {
-      "repository": "powerycy/personal-homepage-skill",
+      "repository": "shengjidaguai-china/personal-homepage-skill",
       "default_branch": "main"
     },
     {
-      "repository": "powerycy/goutoujunshi",
+      "repository": "shengjidaguai-china/goutoujunshi",
       "default_branch": "main"
     },
     {
-      "repository": "powerycy/qiangshou-skill",
+      "repository": "shengjidaguai-china/qiangshou-skill",
       "default_branch": "main"
     },
     {
-      "repository": "powerycy/multi-model-review",
+      "repository": "shengjidaguai-china/multi-model-review",
       "default_branch": "main"
     },
     {
-      "repository": "powerycy/multi-style-image-generator",
+      "repository": "shengjidaguai-china/multi-style-image-generator",
       "default_branch": "main"
     }
   ]

--- a/data/project-status.json
+++ b/data/project-status.json
@@ -1,64 +1,64 @@
 {
-  "checked_at": "2026-08-23T08:21:30.328284Z",
+  "checked_at": "2026-08-26T12:42:47.607745Z",
   "projects": [
     {
-      "repository": "powerycy/BossHunter",
-      "html_url": "https://github.com/powerycy/BossHunter",
+      "repository": "shengjidaguai-china/BossHunter",
+      "html_url": "https://github.com/shengjidaguai-china/BossHunter",
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-23T07:11:42Z",
-      "updated_at": "2026-08-23T07:18:37Z",
+      "pushed_at": "2026-08-25T11:10:16Z",
+      "updated_at": "2026-08-26T12:41:04Z",
       "license": "自定义／未识别"
     },
     {
-      "repository": "powerycy/personal-homepage-skill",
-      "html_url": "https://github.com/powerycy/personal-homepage-skill",
+      "repository": "shengjidaguai-china/personal-homepage-skill",
+      "html_url": "https://github.com/shengjidaguai-china/personal-homepage-skill",
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-08-17T07:59:03Z",
-      "updated_at": "2026-08-23T03:19:01Z",
+      "updated_at": "2026-08-26T12:40:54Z",
       "license": "自定义／未识别"
     },
     {
-      "repository": "powerycy/goutoujunshi",
-      "html_url": "https://github.com/powerycy/goutoujunshi",
+      "repository": "shengjidaguai-china/goutoujunshi",
+      "html_url": "https://github.com/shengjidaguai-china/goutoujunshi",
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-17T07:00:07Z",
-      "updated_at": "2026-08-23T08:20:31Z",
+      "pushed_at": "2026-08-25T10:58:00Z",
+      "updated_at": "2026-08-26T12:41:35Z",
       "license": "MIT"
     },
     {
-      "repository": "powerycy/qiangshou-skill",
-      "html_url": "https://github.com/powerycy/qiangshou-skill",
+      "repository": "shengjidaguai-china/qiangshou-skill",
+      "html_url": "https://github.com/shengjidaguai-china/qiangshou-skill",
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-08-13T10:54:58Z",
-      "updated_at": "2026-08-14T12:05:20Z",
+      "updated_at": "2026-08-26T12:40:50Z",
       "license": "自定义／未识别"
     },
     {
-      "repository": "powerycy/multi-model-review",
-      "html_url": "https://github.com/powerycy/multi-model-review",
+      "repository": "shengjidaguai-china/multi-model-review",
+      "html_url": "https://github.com/shengjidaguai-china/multi-model-review",
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-08-13T10:54:52Z",
-      "updated_at": "2026-08-19T14:47:30Z",
+      "updated_at": "2026-08-26T12:40:50Z",
       "license": "自定义／未识别"
     },
     {
-      "repository": "powerycy/multi-style-image-generator",
-      "html_url": "https://github.com/powerycy/multi-style-image-generator",
+      "repository": "shengjidaguai-china/multi-style-image-generator",
+      "html_url": "https://github.com/shengjidaguai-china/multi-style-image-generator",
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-08-06T07:55:25Z",
-      "updated_at": "2026-08-18T06:18:42Z",
+      "updated_at": "2026-08-26T12:40:52Z",
       "license": "自定义／未识别"
     }
   ]

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,10 +4,6 @@
   简体中文 · <a href="./README_EN.md">English</a>
 </p>
 
-<p align="center">
-  <img src="../assets/logo.png" width="180" alt="升级打怪开源社区 Logo">
-</p>
-
 <h1 align="center">升级打怪开源社区</h1>
 
 <p align="center">
@@ -48,12 +44,12 @@
 
 | 项目 | 你可以参与什么 | 维护者 | 任期 | 状态 |
 | --- | --- | --- | --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |  |  | [招募中](#bosshunter-项目维护者招募) |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |  |  |  |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |  |  |  |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |  |  |  |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |  |  |  |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |  |  |  |
+| [BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 求职 Agent、自动化流程、测试与安全边界 |  |  | [招募中](#bosshunter-项目维护者招募) |
+| [personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 个人主页、HTML PPT、模板与质量检查 |  |  |  |
+| [goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI 关系支持、知识库、测试与安全边界 |  |  |  |
+| [qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 事实核验、技术写作、README 与内容工作流 |  |  |  |
+| [multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 多模型评审、裁判投票与可靠性验证 |  |  |  |
+| [multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 |  |  |  |
 
 完整范围和许可证以[当前共建项目清单](../COMMUNITY_PROJECTS.md)为准。选择一个你真正感兴趣的项目，先看 README、Issue 和许可证，再从一个可以验证的小问题开始。
 

--- a/profile/README_EN.md
+++ b/profile/README_EN.md
@@ -4,10 +4,6 @@
   <a href="./README.md">简体中文</a> · English
 </p>
 
-<p align="center">
-  <img src="../assets/logo.png" width="180" alt="Level Up Open Source Community logo">
-</p>
-
 <h1 align="center">Level Up Open Source Community</h1>
 
 <p align="center">
@@ -48,12 +44,12 @@
 
 | Project | Ways to contribute | Maintainer | Term | Status |
 | --- | --- | --- | --- | --- |
-| [BossHunter](https://github.com/powerycy/BossHunter) | Job-search agents, automation, testing, and safety boundaries |  |  | [Recruiting](#bosshunter-project-maintainer-recruitment) |
-| [personal-homepage-skill](https://github.com/powerycy/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |  |  |  |
-| [goutoujunshi](https://github.com/powerycy/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |  |  |  |
-| [qiangshou-skill](https://github.com/powerycy/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |  |  |  |
-| [multi-model-review](https://github.com/powerycy/multi-model-review) | Multi-model review, judge voting, and reliability checks |  |  |  |
-| [multi-style-image-generator](https://github.com/powerycy/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |  |  |  |
+| [BossHunter](https://github.com/shengjidaguai-china/BossHunter) | Job-search agents, automation, testing, and safety boundaries |  |  | [Recruiting](#bosshunter-project-maintainer-recruitment) |
+| [personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | Personal sites, HTML slide decks, templates, and quality checks |  |  |  |
+| [goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI relationship support, knowledge sources, tests, and safety boundaries |  |  |  |
+| [qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | Fact checking, technical writing, READMEs, and content workflows |  |  |  |
+| [multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | Multi-model review, judge voting, and reliability checks |  |  |  |
+| [multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | Multi-style image generation and 360° spatial previews |  |  |  |
 
 The [community project registry](../COMMUNITY_PROJECTS.md) is the source of truth for scope and licensing. Read the project's README, issues, and license before contributing, then begin with one verifiable problem.
 

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -11,12 +11,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_PROJECTS = {
-    "powerycy/BossHunter",
-    "powerycy/personal-homepage-skill",
-    "powerycy/goutoujunshi",
-    "powerycy/qiangshou-skill",
-    "powerycy/multi-model-review",
-    "powerycy/multi-style-image-generator",
+    "shengjidaguai-china/BossHunter",
+    "shengjidaguai-china/personal-homepage-skill",
+    "shengjidaguai-china/goutoujunshi",
+    "shengjidaguai-china/qiangshou-skill",
+    "shengjidaguai-china/multi-model-review",
+    "shengjidaguai-china/multi-style-image-generator",
 }
 LEDGER_URL = (
     "https://wcng30x0nvef.feishu.cn/base/"
@@ -109,4 +109,3 @@ if __name__ == "__main__":
     except (AssertionError, json.JSONDecodeError) as exc:
         print(f"Community repository validation: FAIL: {exc}", file=sys.stderr)
         sys.exit(1)
-


### PR DESCRIPTION
## Summary
- remove the repeated logo from Chinese and English homepage content
- update all six community project links and allowlists to the organization
- refresh the public project status snapshot after repository transfers

## Verification
- `python3 scripts/validate_repository.py`
- `git diff --check`