### PR TITLE
docs: 收录销冠社区项目

### DIFF
--- a/COMMUNITY_PROJECTS.md
+++ b/COMMUNITY_PROJECTS.md
@@ -7,6 +7,7 @@
 | [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | AI 求职 Agent 与自动化流程 |  |  | [招募中](./README.md#bosshunter-项目维护者招募) | `main` | 自定义非商业许可证；商用需事先书面授权 |
 | [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 个人主页与 HTML PPT 生成 Skill |  |  |  | `main` | 自定义非商业许可证；商用需事先书面授权 |
 | [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI 恋爱军师与关系支持 Skill |  |  |  | `main` | MIT License |
+| [shengjidaguai-china/xiaoguan](https://github.com/shengjidaguai-china/xiaoguan) | 面向个人与 B 端销售的本地客户军师、成交教练与混合 RAG Skill | [@powerycy](https://github.com/powerycy) |  | 共建中 | `main` | PolyForm Noncommercial License 1.0.0 |
 | [shengjidaguai-china/qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 事实核验与技术内容写作 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
 | [shengjidaguai-china/multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 多模型评审与裁判投票 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |
 | [shengjidaguai-china/multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 多风格图片生成与 360° 空间预览 Skill |  |  |  | `main` | PolyForm Noncommercial License 1.0.0 |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,15 +4,16 @@
 
 本页面每月核对一次已收录仓库的公开状态、默认分支、最后推送时间和 GitHub 检测到的许可证。贡献署名和贡献者页面由各项目独立维护。
 
-最近检查：`2026-08-26T12:42:47.607745Z`
+最近检查：`2026-09-01T08:28:53.712868Z`
 
 | 项目 | 状态 | 默认分支 | 最后推送 | GitHub 许可证识别 |
 | --- | --- | --- | --- | --- |
-| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 公开 | `main` | 2026-08-25T11:10:16Z | 自定义／未识别 |
-| [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 公开 | `main` | 2026-08-17T07:59:03Z | 自定义／未识别 |
-| [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | 公开 | `main` | 2026-08-25T10:58:00Z | MIT |
-| [shengjidaguai-china/qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 公开 | `main` | 2026-08-13T10:54:58Z | 自定义／未识别 |
-| [shengjidaguai-china/multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 公开 | `main` | 2026-08-13T10:54:52Z | 自定义／未识别 |
-| [shengjidaguai-china/multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 公开 | `main` | 2026-08-06T07:55:25Z | 自定义／未识别 |
+| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 公开 | `main` | 2026-09-01T02:54:04Z | 未检测到 |
+| [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 公开 | `main` | 2026-08-26T15:44:18Z | 自定义／未识别 |
+| [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | 公开 | `main` | 2026-08-27T11:19:05Z | MIT |
+| [shengjidaguai-china/xiaoguan](https://github.com/shengjidaguai-china/xiaoguan) | 公开 | `main` | 2026-09-01T08:27:09Z | 自定义／未识别 |
+| [shengjidaguai-china/qiangshou-skill](https://github.com/shengjidaguai-china/qiangshou-skill) | 公开 | `main` | 2026-08-30T12:19:32Z | 自定义／未识别 |
+| [shengjidaguai-china/multi-model-review](https://github.com/shengjidaguai-china/multi-model-review) | 公开 | `main` | 2026-08-26T15:44:25Z | 自定义／未识别 |
+| [shengjidaguai-china/multi-style-image-generator](https://github.com/shengjidaguai-china/multi-style-image-generator) | 公开 | `main` | 2026-08-26T15:44:33Z | 自定义／未识别 |
 
 GitHub 显示“自定义／未识别”时，以仓库实际 `LICENSE` 文件为准。人工确认的范围和许可证说明见 [`COMMUNITY_PROJECTS.md`](./COMMUNITY_PROJECTS.md)。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-28 -->
+<!-- README_SYNC: source=working-tree; updated=2026-09-01 -->
 
 <p align="center">
   简体中文 · <a href="./README_EN.md">English</a>
@@ -77,6 +77,10 @@
   <tr>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-model-review"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-model-review.svg" alt="multi-model-review 项目卡片"></a></td>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-style-image-generator"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-style-image-generator.svg" alt="multi-style-image-generator 项目卡片"></a></td>
+  </tr>
+  <tr>
+    <td width="50%"><a href="https://github.com/shengjidaguai-china/xiaoguan"><img src="https://gh-card.dev/repos/shengjidaguai-china/xiaoguan.svg" alt="销冠项目卡片"></a></td>
+    <td width="50%"></td>
   </tr>
 </table>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-27 -->
+<!-- README_SYNC: source=working-tree; updated=2026-09-01 -->
 
 <p align="center">
   <a href="./README.md">简体中文</a> · English
@@ -75,6 +75,10 @@ Individuals and teams may apply.
   <tr>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-model-review"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-model-review.svg" alt="multi-model-review repository card"></a></td>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-style-image-generator"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-style-image-generator.svg" alt="multi-style-image-generator repository card"></a></td>
+  </tr>
+  <tr>
+    <td width="50%"><a href="https://github.com/shengjidaguai-china/xiaoguan"><img src="https://gh-card.dev/repos/shengjidaguai-china/xiaoguan.svg" alt="Xiaoguan repository card"></a></td>
+    <td width="50%"></td>
   </tr>
 </table>
 

--- a/config/community.json
+++ b/config/community.json
@@ -17,6 +17,10 @@
       "default_branch": "main"
     },
     {
+      "repository": "shengjidaguai-china/xiaoguan",
+      "default_branch": "main"
+    },
+    {
       "repository": "shengjidaguai-china/qiangshou-skill",
       "default_branch": "main"
     },

--- a/data/project-status.json
+++ b/data/project-status.json
@@ -1,5 +1,5 @@
 {
-  "checked_at": "2026-08-26T12:42:47.607745Z",
+  "checked_at": "2026-09-01T08:28:53.712868Z",
   "projects": [
     {
       "repository": "shengjidaguai-china/BossHunter",
@@ -7,9 +7,9 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-25T11:10:16Z",
-      "updated_at": "2026-08-26T12:41:04Z",
-      "license": "自定义／未识别"
+      "pushed_at": "2026-09-01T02:54:04Z",
+      "updated_at": "2026-09-01T07:11:03Z",
+      "license": "未检测到"
     },
     {
       "repository": "shengjidaguai-china/personal-homepage-skill",
@@ -17,8 +17,8 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-17T07:59:03Z",
-      "updated_at": "2026-08-26T12:40:54Z",
+      "pushed_at": "2026-08-26T15:44:18Z",
+      "updated_at": "2026-09-01T07:15:24Z",
       "license": "自定义／未识别"
     },
     {
@@ -27,9 +27,19 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-25T10:58:00Z",
-      "updated_at": "2026-08-26T12:41:35Z",
+      "pushed_at": "2026-08-27T11:19:05Z",
+      "updated_at": "2026-09-01T08:24:42Z",
       "license": "MIT"
+    },
+    {
+      "repository": "shengjidaguai-china/xiaoguan",
+      "html_url": "https://github.com/shengjidaguai-china/xiaoguan",
+      "state": "公开",
+      "default_branch": "main",
+      "configured_default_branch": "main",
+      "pushed_at": "2026-09-01T08:27:09Z",
+      "updated_at": "2026-09-01T08:24:55Z",
+      "license": "自定义／未识别"
     },
     {
       "repository": "shengjidaguai-china/qiangshou-skill",
@@ -37,8 +47,8 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-13T10:54:58Z",
-      "updated_at": "2026-08-26T12:40:50Z",
+      "pushed_at": "2026-08-30T12:19:32Z",
+      "updated_at": "2026-08-31T11:52:26Z",
       "license": "自定义／未识别"
     },
     {
@@ -47,8 +57,8 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-13T10:54:52Z",
-      "updated_at": "2026-08-26T12:40:50Z",
+      "pushed_at": "2026-08-26T15:44:25Z",
+      "updated_at": "2026-08-29T22:23:52Z",
       "license": "自定义／未识别"
     },
     {
@@ -57,8 +67,8 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-08-06T07:55:25Z",
-      "updated_at": "2026-08-26T12:40:52Z",
+      "pushed_at": "2026-08-26T15:44:33Z",
+      "updated_at": "2026-09-01T03:39:57Z",
       "license": "自定义／未识别"
     }
   ]

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-28 -->
+<!-- README_SYNC: source=working-tree; updated=2026-09-01 -->
 
 <p align="center">
   简体中文 · <a href="./README_EN.md">English</a>
@@ -77,6 +77,10 @@
   <tr>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-model-review"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-model-review.svg" alt="multi-model-review 项目卡片"></a></td>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-style-image-generator"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-style-image-generator.svg" alt="multi-style-image-generator 项目卡片"></a></td>
+  </tr>
+  <tr>
+    <td width="50%"><a href="https://github.com/shengjidaguai-china/xiaoguan"><img src="https://gh-card.dev/repos/shengjidaguai-china/xiaoguan.svg" alt="销冠项目卡片"></a></td>
+    <td width="50%"></td>
   </tr>
 </table>
 

--- a/profile/README_EN.md
+++ b/profile/README_EN.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=working-tree; updated=2026-08-27 -->
+<!-- README_SYNC: source=working-tree; updated=2026-09-01 -->
 
 <p align="center">
   <a href="./README.md">简体中文</a> · English
@@ -75,6 +75,10 @@ Individuals and teams may apply.
   <tr>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-model-review"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-model-review.svg" alt="multi-model-review repository card"></a></td>
     <td width="50%"><a href="https://github.com/shengjidaguai-china/multi-style-image-generator"><img src="https://gh-card.dev/repos/shengjidaguai-china/multi-style-image-generator.svg" alt="multi-style-image-generator repository card"></a></td>
+  </tr>
+  <tr>
+    <td width="50%"><a href="https://github.com/shengjidaguai-china/xiaoguan"><img src="https://gh-card.dev/repos/shengjidaguai-china/xiaoguan.svg" alt="Xiaoguan repository card"></a></td>
+    <td width="50%"></td>
   </tr>
 </table>
 

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -14,6 +14,7 @@ EXPECTED_PROJECTS = {
     "shengjidaguai-china/BossHunter",
     "shengjidaguai-china/personal-homepage-skill",
     "shengjidaguai-china/goutoujunshi",
+    "shengjidaguai-china/xiaoguan",
     "shengjidaguai-china/qiangshou-skill",
     "shengjidaguai-china/multi-model-review",
     "shengjidaguai-china/multi-style-image-generator",
@@ -42,6 +43,8 @@ def check_public_homepages() -> None:
             fail(f"missing README sync marker: {page.relative_to(ROOT)}")
         if "multi-style-image-generator" not in text:
             fail(f"missing current project: {page.relative_to(ROOT)}")
+        if "shengjidaguai-china/xiaoguan" not in text:
+            fail(f"missing Xiaoguan project: {page.relative_to(ROOT)}")
         if "xiyouji-interactive-museum" in text:
             fail(f"removed project still present: {page.relative_to(ROOT)}")
 


### PR DESCRIPTION
## 这次改变了什么

将 `shengjidaguai-china/xiaoguan` 纳入升级打怪开源社区：

- 在中英文主页与组织 Profile 展示项目卡片；
- 更新项目清单、自动状态配置和生成状态；
- 将项目登记为“共建中”，维护者为 @powerycy；
- 许可证为 PolyForm Noncommercial License 1.0.0；
- 新手入口：shengjidaguai-china/xiaoguan#5。

项目定位：面向个人与 B 端销售的本地客户军师、成交教练与混合 RAG Skill。与现有狗头军师的差异在于销售成交场景、客户决策分析与本地混合 RAG，而非亲密关系支持。

## 证据与影响范围

- 关联 Issue：shengjidaguai-china/xiaoguan#5
- 影响的项目或规则：社区项目清单、首页项目卡片、月度状态配置
- 是否涉及许可证、资金、权限或个人信息：涉及项目许可证登记；不涉及资金和个人信息

## 自检

- [x] 项目状态、许可证和维护信息均有真实依据
- [x] 贡献署名和贡献者名单继续由对应项目维护
- [x] 中英文主页的共同事实已同步
- [x] 本地测试、仓库结构和链接校验通过