### PR TITLE
docs: sync BossHunter license status

### DIFF
--- a/COMMUNITY_PROJECTS.md
+++ b/COMMUNITY_PROJECTS.md
@@ -4,7 +4,7 @@
 
 | 项目 | 定位 | 维护者 | 任期 | 状态 | 默认分支 | 当前许可证口径 |
 | --- | --- | --- | --- | --- | --- | --- |
-| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | AI 求职 Agent 与自动化流程 |  |  | [招募中](./README.md#bosshunter-项目维护者招募) | `main` | 自定义非商业许可证；商用需事先书面授权 |
+| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | AI 求职 Agent 与自动化流程 |  |  | [招募中](./README.md#bosshunter-项目维护者招募) | `main` | 源码公开（source-available）；PolyForm Noncommercial License 1.0.0（非商业许可，商用需另行书面授权） |
 | [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 个人主页与 HTML PPT 生成 Skill |  |  |  | `main` | 自定义非商业许可证；商用需事先书面授权 |
 | [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | AI 恋爱军师与关系支持 Skill |  |  |  | `main` | MIT License |
 | [shengjidaguai-china/xiaoguan](https://github.com/shengjidaguai-china/xiaoguan) | 面向个人与 B 端销售的本地客户军师、成交教练与混合 RAG Skill | [@powerycy](https://github.com/powerycy) |  | 共建中 | `main` | PolyForm Noncommercial License 1.0.0 |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,11 +4,11 @@
 
 本页面每月核对一次已收录仓库的公开状态、默认分支、最后推送时间和 GitHub 检测到的许可证。贡献署名和贡献者页面由各项目独立维护。
 
-最近检查：`2026-09-01T08:28:53.712868Z`
+最近检查：`2026-09-01T12:22:14.759520Z`
 
 | 项目 | 状态 | 默认分支 | 最后推送 | GitHub 许可证识别 |
 | --- | --- | --- | --- | --- |
-| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 公开 | `main` | 2026-09-01T02:54:04Z | 未检测到 |
+| [shengjidaguai-china/BossHunter](https://github.com/shengjidaguai-china/BossHunter) | 公开 | `main` | 2026-09-01T12:21:15Z | 自定义／未识别 |
 | [shengjidaguai-china/personal-homepage-skill](https://github.com/shengjidaguai-china/personal-homepage-skill) | 公开 | `main` | 2026-08-26T15:44:18Z | 自定义／未识别 |
 | [shengjidaguai-china/goutoujunshi](https://github.com/shengjidaguai-china/goutoujunshi) | 公开 | `main` | 2026-08-27T11:19:05Z | MIT |
 | [shengjidaguai-china/xiaoguan](https://github.com/shengjidaguai-china/xiaoguan) | 公开 | `main` | 2026-09-01T08:27:09Z | 自定义／未识别 |

--- a/data/project-status.json
+++ b/data/project-status.json
@@ -1,5 +1,5 @@
 {
-  "checked_at": "2026-09-01T08:28:53.712868Z",
+  "checked_at": "2026-09-01T12:22:14.759520Z",
   "projects": [
     {
       "repository": "shengjidaguai-china/BossHunter",
@@ -7,9 +7,9 @@
       "state": "公开",
       "default_branch": "main",
       "configured_default_branch": "main",
-      "pushed_at": "2026-09-01T02:54:04Z",
-      "updated_at": "2026-09-01T07:11:03Z",
-      "license": "未检测到"
+      "pushed_at": "2026-09-01T12:21:15Z",
+      "updated_at": "2026-09-01T12:21:33Z",
+      "license": "自定义／未识别"
     },
     {
       "repository": "shengjidaguai-china/personal-homepage-skill",
@@ -18,7 +18,7 @@
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-08-26T15:44:18Z",
-      "updated_at": "2026-09-01T07:15:24Z",
+      "updated_at": "2026-09-01T12:16:47Z",
       "license": "自定义／未识别"
     },
     {
@@ -28,7 +28,7 @@
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-08-27T11:19:05Z",
-      "updated_at": "2026-09-01T08:24:42Z",
+      "updated_at": "2026-09-01T12:14:39Z",
       "license": "MIT"
     },
     {
@@ -38,7 +38,7 @@
       "default_branch": "main",
       "configured_default_branch": "main",
       "pushed_at": "2026-09-01T08:27:09Z",
-      "updated_at": "2026-09-01T08:24:55Z",
+      "updated_at": "2026-09-01T08:38:21Z",
       "license": "自定义／未识别"
     },
     {


### PR DESCRIPTION
## 修改

- 将 BossHunter 的人工许可证口径更新为 source-available / PolyForm Noncommercial License 1.0.0
- 通过现有 scripts/update_project_status.py 重新生成 PROJECT_STATUS.md 与 data/project-status.json
- config/community.json 无事实变化，保持不动

GitHub 对 PolyForm 显示为“自定义／未识别”，人工清单用于明确实际许可证与非商业范围。

## 验证

- python -m unittest discover -s tests -v：3 项通过
- python scripts/validate_repository.py：PASS
- 3 个 JSON 文件解析通过
- git diff --check